### PR TITLE
docs: fix an inaccuracy on explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ---
 
-## Installation
+## Installation and Usage
 
 ### Clone
 
@@ -75,7 +75,7 @@ $ yarn
 $ yarn android
 ```
 
-> Open another terminal window an run the metro bundler with
+> Open another terminal window on mobile folder an run the metro bundler with
 
 ```shell
 $ yarn start


### PR DESCRIPTION
There is a fault on mobile usage explanation, when i said "open another terminal window" i forgot to say to open this new terminal window on mobile's folder.